### PR TITLE
Move the toggle to a Ensage.Menu switch

### DIFF
--- a/AxeBlinkUlti/Program.cs
+++ b/AxeBlinkUlti/Program.cs
@@ -1,13 +1,10 @@
-﻿using System;
+using System;
 using System.Linq;
-using System.Collections.Generic;
-using System.Windows.Input;
 
 using Ensage;
-using SharpDX;
 using Ensage.Common.Extensions;
 using Ensage.Common;
-using SharpDX.Direct3D9;
+using Ensage.Common.Menu;
 
 namespace AxeBlinkUlti
 {
@@ -17,37 +14,25 @@ namespace AxeBlinkUlti
         private static Item Blink;
         private static Hero me;
         private static Hero target;
-        private static Key toggleKey = Key.J;
-        private static bool toggle = true;
-        private static Font _text;
-        private static int[] _ChopDmg = new int[3];
+        private static int[] _chopDmg = new int[3];
         private static int minimumDistance = 400;
+        private static readonly Menu Menu = new Menu("AxeBlinkUlti", "axeblinkulti", true);
+
+
+
 
         static void Main(string[] args)
         {
+            Menu.AddItem(new MenuItem("toggle", "Enabled").SetValue(true));
+            Menu.AddToMainMenu();
             Game.OnUpdate += Game_OnUpdate;
-            Game.OnWndProc += Game_OnWndProc;
             Console.WriteLine("> AxeBlinkUlti loaded!");
-
-            _text = new Font(
-               Drawing.Direct3DDevice9,
-               new FontDescription
-               {
-                   FaceName = "Tahoma",
-                   Height = 11,
-                   OutputPrecision = FontPrecision.Default,
-                   Quality = FontQuality.Default
-               });
-                Drawing.OnPreReset += Drawing_OnPreReset;
-                Drawing.OnPostReset += Drawing_OnPostReset;
-                Drawing.OnEndScene += Drawing_OnEndScene;
-                AppDomain.CurrentDomain.DomainUnload += CurrentDomain_DomainUnload;
         }
 
         public static void Game_OnUpdate(EventArgs args)
         {
-            me = ObjectMgr.LocalHero;
-
+            me = ObjectManager.LocalHero;
+            
             if (me.ClassID != ClassID.CDOTA_Unit_Hero_Axe)
                 return;
             if (me == null)
@@ -61,16 +46,16 @@ namespace AxeBlinkUlti
 
             if (me.HasItem(ClassID.CDOTA_Item_UltimateScepter))
             {
-                _ChopDmg = new int[3] { 300, 425, 550 };
+                _chopDmg = new int[3] { 300, 425, 550 };
             }
             else
             {
-                _ChopDmg = new int[3] { 250, 325, 400 };
+                _chopDmg = new int[3] { 250, 325, 400 };
             }
 
-            var ChopDmg = _ChopDmg[Chop.Level - 1];
+            var ChopDmg = _chopDmg[Chop.Level - 1];
 
-            if (toggle)
+            if (Menu.Item("toggle").GetValue<bool>())
             {
                 var enemies = ObjectMgr.GetEntities<Hero>().Where(x => x.IsVisible && x.IsAlive && !x.IsIllusion && x.Team != me.Team && x.Health <= ChopDmg).ToList();
 
@@ -101,53 +86,6 @@ namespace AxeBlinkUlti
                     }
                 }
             }
-        }
-
-        private static void Game_OnWndProc(WndEventArgs args)
-        {
-            if (!Game.IsChatOpen)
-            {
-                if (Game.IsKeyDown(toggleKey) && Utils.SleepCheck("toggle"))
-                {
-                    toggle = !toggle;
-                    Utils.Sleep(300, "toggle");
-                }
-            }
-        }
-
-        static void CurrentDomain_DomainUnload(object sender, EventArgs e)
-        {
-            _text.Dispose();
-        }
-
-        static void Drawing_OnEndScene(EventArgs args)
-        {
-            if (Drawing.Direct3DDevice9 == null || Drawing.Direct3DDevice9.IsDisposed || !Game.IsInGame)
-                return;
-
-            var player = ObjectMgr.LocalPlayer;
-            var me = ObjectMgr.LocalHero;
-            if (player == null || player.Team == Team.Observer || me.ClassID != ClassID.CDOTA_Unit_Hero_Axe)
-                return;
-
-            if (toggle)
-            {
-                _text.DrawText(null, "AxeBlinkUlti: Enabled | [" + toggleKey + "] for toggle", 4, 180, Color.White);
-            }
-            else
-            {
-                _text.DrawText(null, "AxeBlinkUlti: Disabled | [" + toggleKey + "] for toggle", 4, 180, Color.WhiteSmoke);
-            }
-        }
-
-        static void Drawing_OnPostReset(EventArgs args)
-        {
-            _text.OnResetDevice();
-        }
-
-        static void Drawing_OnPreReset(EventArgs args)
-        {
-            _text.OnLostDevice();
         }
     }
 }


### PR DESCRIPTION
Now uses a ensage.Menu toggle switch to enable and disable it.

Preview:

![!](http://i.imgur.com/ictzMTB.png)

Also lowercased C in _chopDmg to comply with the private variable standards. Completely unnecessary but it doesn't make a difference.
